### PR TITLE
Fix: Restore iOS tap status bar to scroll to top functionality

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,7 +48,6 @@ html {
   padding: 0;
   overscroll-behavior: none;
   -webkit-overflow-scrolling: touch;
-  overflow: hidden; /* Prevent any rubber-band scroll of the root */
   background-color: #23252e; /* Fallback color matching the dark end of gradient */
 }
 
@@ -62,7 +61,6 @@ body {
   background: transparent; /* Let aurora-bg show through body */
   /* Prevent iOS overscroll effects */
   overscroll-behavior: none;
-  overflow: hidden; /* Prevent any rubber-band scroll of the root */
 }
 
 /* Aurora background styles moved to app/styles/components/aurora.css */
@@ -70,8 +68,6 @@ body {
 .portfolio-container {
   width: 100%;
   min-height: 100vh; /* Fallback if JS fails or before it runs */
-  height: 100vh; /* Standard viewport height */
-  overflow-y: auto;
   overflow-x: hidden;
   scroll-behavior: smooth;
   position: relative;


### PR DESCRIPTION
Previously, the native iOS feature to scroll to the top of the page by tapping the status bar was not working. This was due to `overflow: hidden` being set on the `html` and `body` elements, and a fixed `height` with `overflow-y: auto` on the `portfolio-container` class.

This commit addresses the issue by:
- Removing `overflow: hidden` from `html` and `body` in `app/globals.css`.
- Removing `height: 100vh` and `overflow-y: auto` from `.portfolio-container` in `app/globals.css`. The existing `min-height: 100vh` will ensure the container still occupies at least the full viewport height.

These changes allow the main document to be scrollable, which is required for the iOS tap-to-top gesture to function correctly.