### PR TITLE
Revert html/body overflow to hidden

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,8 +47,8 @@ html {
   margin: 0;
   padding: 0;
   -webkit-overflow-scrolling: touch;
-  /* Allow iOS safari top bar interactions */
-  overflow-y: auto; /* Permit native scrolling behavior */
+  /* Modified to allow iOS safari top bar interactions */
+  overflow: hidden; /* Prevent any rubber-band scroll of the root */
   background-color: #23252e; /* Fallback color matching the dark end of gradient */
 }
 
@@ -60,8 +60,8 @@ body {
   color: #ffffff;
   font-family: var(--font-manrope), var(--font-fallback);
   background: transparent; /* Let aurora-bg show through body */
-  /* Allow iOS native interactions */
-  overflow-y: auto; /* Permit native scrolling behavior */
+  /* Modified to allow iOS native interactions */
+  overflow: hidden; /* Prevent any rubber-band scroll of the root */
 }
 
 /* Aurora background styles moved to app/styles/components/aurora.css */


### PR DESCRIPTION
## Summary
- revert overflow on html and body back to `hidden`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5de98bec8326a83df88c10746608