### PR TITLE
Hide Based Chat and Colorbookorama from portfolio and timeline

### DIFF
--- a/app/sections/PortfolioSection.tsx
+++ b/app/sections/PortfolioSection.tsx
@@ -7,7 +7,11 @@ import Colorbookorama from "@components/projects/Colorbookorama";
 import { projects } from "@/content/projects";
 import { useEntranceStagger, useActiveSection } from "@lib/hooks";
 
-const CUSTOM_PROJECT_IDS = ["basedchat", "colorbookorama"] as const;
+// Keep these cards wired for easy future re-enable without deleting component code.
+const SHOW_CUSTOM_PROJECTS = false;
+const CUSTOM_PROJECT_IDS = SHOW_CUSTOM_PROJECTS
+  ? (["basedchat", "colorbookorama"] as const)
+  : ([] as const);
 const CUSTOM_LABELS: Record<(typeof CUSTOM_PROJECT_IDS)[number], string> = {
   basedchat: "Based Chat",
   colorbookorama: "Colorbookorama",
@@ -136,12 +140,16 @@ const PortfolioSection = forwardRef<HTMLDivElement>(function PortfolioSection(_,
                 </div>
               );
             })}
-            <div ref={projectRefs["basedchat"]} data-project-card>
-              <BasedChat />
-            </div>
-            <div ref={projectRefs["colorbookorama"]} data-project-card>
-              <Colorbookorama />
-            </div>
+            {SHOW_CUSTOM_PROJECTS && (
+              <>
+                <div ref={projectRefs["basedchat"]} data-project-card>
+                  <BasedChat />
+                </div>
+                <div ref={projectRefs["colorbookorama"]} data-project-card>
+                  <Colorbookorama />
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Temporarily remove the `BasedChat` and `Colorbookorama` project cards and their timeline entries without deleting code so they can be re-enabled later.

### Description
- Add a `SHOW_CUSTOM_PROJECTS` flag (default `false`) in `app/sections/PortfolioSection.tsx` to control whether the two custom cards render.
- Conditionally include the custom project IDs in the timeline (`timelineIds`) only when the flag is enabled so the table-of-contents no longer lists them.
- Wrap the `BasedChat` and `Colorbookorama` render blocks with the feature flag and keep imports intact to preserve implementation for quick re-enable.

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors (passed).
- Started the dev server with `npm run dev` and the app booted successfully for manual verification (server start succeeded).
- Attempted an automated Playwright screenshot of the running site which timed out/crashed in this environment (browser run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699947e9ef8c8326a97cbd4362687b78)